### PR TITLE
fix error at host api and change output param

### DIFF
--- a/src/ZabbixApi/Entities/DiscoveryRule.cs
+++ b/src/ZabbixApi/Entities/DiscoveryRule.cs
@@ -69,6 +69,7 @@ namespace ZabbixApi.Entities
         /// </summary>
         public IList<DiscoveredHost> selectDHosts { get; set; }
 
+        public IList<DiscoveryCheck> dchecks { get; set; }
         #endregion
 
         #region ENUMS
@@ -85,6 +86,7 @@ namespace ZabbixApi.Entities
         {
             delay = 3600;
             status = Status.Enabled;
+            dchecks = new List<DiscoveryCheck>();
         }
 
         #endregion

--- a/src/ZabbixApi/Entities/Host.cs
+++ b/src/ZabbixApi/Entities/Host.cs
@@ -229,6 +229,36 @@ namespace ZabbixApi.Entities
         /// </summary>
         public Status status { get; set; }
 
+        /// <summary>
+        /// Host inventory population mode. 
+        /// 
+        /// Possible values are: 
+        /// -1 - Disabled; 
+        /// 0 - Manual; 
+        /// 1 - Automatic; 
+        /// 
+        /// </summary>
+        private int _inventory_mode=(int)HostInventory.InventoryMode.Disabled;
+        public int inventory_mode
+        {
+            get
+            {
+                if (inventory != null)
+                {
+                    _inventory_mode = inventory.inventory_mode ;
+                }
+                return _inventory_mode;
+
+            }
+            set
+            {
+                _inventory_mode = value;
+                if (inventory != null)
+                {
+                    inventory.inventory_mode = _inventory_mode ;
+                }
+            }
+        }
         #endregion
 
         #region Associations

--- a/src/ZabbixApi/Entities/HostInventory.cs
+++ b/src/ZabbixApi/Entities/HostInventory.cs
@@ -16,6 +16,9 @@ namespace ZabbixApi.Entities
         /// (readonly) ID of the host.
         /// </summary>
         [JsonProperty("hostid")]
+        public string hostidSetter { set { Id = value; } }
+
+        [JsonIgnore]
         public string Id { get; set; }
 
         /// <summary>
@@ -114,6 +117,10 @@ namespace ZabbixApi.Entities
         /// 1 - Automatic; 
         /// 
         /// </summary>
+        [JsonProperty("inventory_mode")]
+        public int inventory_modeSetter { set { inventory_mode = value; } }
+
+        [JsonIgnore]
         public int inventory_mode { get; set; }
 
         /// <summary>

--- a/src/ZabbixApi/Services/ActionService.cs
+++ b/src/ZabbixApi/Services/ActionService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectConditions", includeHelper.WhatShouldInclude(ActionInclude.Conditions));
             @params.AddOrReplace("selectOperations", includeHelper.WhatShouldInclude(ActionInclude.Operations));
 

--- a/src/ZabbixApi/Services/AlertService.cs
+++ b/src/ZabbixApi/Services/AlertService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(AlertInclude.Hosts));
             @params.AddOrReplace("selectMediatypes", includeHelper.WhatShouldInclude(AlertInclude.MediaTypes));
             @params.AddOrReplace("selectUsers", includeHelper.WhatShouldInclude(AlertInclude.Users));

--- a/src/ZabbixApi/Services/ApplicationService.cs
+++ b/src/ZabbixApi/Services/ApplicationService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(ApplicationInclude.Hosts));
             @params.AddOrReplace("selectItems", includeHelper.WhatShouldInclude(ApplicationInclude.Items));
 

--- a/src/ZabbixApi/Services/DiscoveredHostService.cs
+++ b/src/ZabbixApi/Services/DiscoveredHostService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectDRules", includeHelper.WhatShouldInclude(DiscoveredHostInclude.DiscoveryRules));
             @params.AddOrReplace("selectDServices", includeHelper.WhatShouldInclude(DiscoveredHostInclude.DiscoveredServices));
 

--- a/src/ZabbixApi/Services/DiscoveredServiceService.cs
+++ b/src/ZabbixApi/Services/DiscoveredServiceService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectDRules", includeHelper.WhatShouldInclude(DiscoveredServiceInclude.DiscoveryRules));
             @params.AddOrReplace("selectDServices", includeHelper.WhatShouldInclude(DiscoveredServiceInclude.DiscoveredServices));
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(DiscoveredServiceInclude.Hosts));

--- a/src/ZabbixApi/Services/DiscoveryCheckService.cs
+++ b/src/ZabbixApi/Services/DiscoveryCheckService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
 
             @params.AddOrReplace("filter", filter);
             

--- a/src/ZabbixApi/Services/DiscoveryRuleService.cs
+++ b/src/ZabbixApi/Services/DiscoveryRuleService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectDHosts", includeHelper.WhatShouldInclude(DiscoveryRuleInclude.DiscoveredHosts));
             @params.AddOrReplace("selectDChecks", includeHelper.WhatShouldInclude(DiscoveryRuleInclude.DiscoveryChecks));
 

--- a/src/ZabbixApi/Services/EventService.cs
+++ b/src/ZabbixApi/Services/EventService.cs
@@ -32,7 +32,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(EventInclude.Hosts));
             @params.AddOrReplace("selectRelatedObject", includeHelper.WhatShouldInclude(EventInclude.RelatedObject));
             @params.AddOrReplace("select_alerts", includeHelper.WhatShouldInclude(EventInclude.Alerts));

--- a/src/ZabbixApi/Services/GraphItemService.cs
+++ b/src/ZabbixApi/Services/GraphItemService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectGraphs", includeHelper.WhatShouldInclude(GraphItemInclude.Graphs));
 
             @params.AddOrReplace("filter", filter);

--- a/src/ZabbixApi/Services/GraphPrototypeService.cs
+++ b/src/ZabbixApi/Services/GraphPrototypeService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectDiscoveryRule", includeHelper.WhatShouldInclude(GraphPrototypeInclude.DiscoveryRule));
             @params.AddOrReplace("selectGraphItems", includeHelper.WhatShouldInclude(GraphPrototypeInclude.GraphItems));
             @params.AddOrReplace("selectGroups", includeHelper.WhatShouldInclude(GraphPrototypeInclude.Groups));

--- a/src/ZabbixApi/Services/GraphService.cs
+++ b/src/ZabbixApi/Services/GraphService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectGroups", includeHelper.WhatShouldInclude(GraphInclude.Groups));
             @params.AddOrReplace("selectTemplates", includeHelper.WhatShouldInclude(GraphInclude.Templates));
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(GraphInclude.Hosts));

--- a/src/ZabbixApi/Services/HistoryService.cs
+++ b/src/ZabbixApi/Services/HistoryService.cs
@@ -30,7 +30,7 @@ namespace ZabbixApi.Services
             if (@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
 
             @params.AddOrReplace("filter", filter);
 

--- a/src/ZabbixApi/Services/HostGroupService.cs
+++ b/src/ZabbixApi/Services/HostGroupService.cs
@@ -28,7 +28,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectDiscoveryRule", includeHelper.WhatShouldInclude(HostGroupInclude.DiscoveryRule));
             @params.AddOrReplace("selectGroupDiscovery", includeHelper.WhatShouldInclude(HostGroupInclude.GroupDiscovery));
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(HostGroupInclude.Hosts));

--- a/src/ZabbixApi/Services/HostInterfaceService.cs
+++ b/src/ZabbixApi/Services/HostInterfaceService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectItems", includeHelper.WhatShouldInclude(HostInterfaceInclude.Items));
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(HostInterfaceInclude.Hosts));
 

--- a/src/ZabbixApi/Services/HostPrototypeService.cs
+++ b/src/ZabbixApi/Services/HostPrototypeService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectDiscoveryRule", includeHelper.WhatShouldInclude(HostPrototypeInclude.DiscoveryRule));
             @params.AddOrReplace("selectGroupLinks", includeHelper.WhatShouldInclude(HostPrototypeInclude.GroupLinks));
             @params.AddOrReplace("selectGroupPrototypes", includeHelper.WhatShouldInclude(HostPrototypeInclude.GroupPrototypes));

--- a/src/ZabbixApi/Services/HostService.cs
+++ b/src/ZabbixApi/Services/HostService.cs
@@ -28,7 +28,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectGroups", includeHelper.WhatShouldInclude(HostInclude.Groups));
             @params.AddOrReplace("selectApplications", includeHelper.WhatShouldInclude(HostInclude.Applications));
             @params.AddOrReplace("selectDiscoveries", includeHelper.WhatShouldInclude(HostInclude.Discoveries));

--- a/src/ZabbixApi/Services/ITServiceService.cs
+++ b/src/ZabbixApi/Services/ITServiceService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectParent", includeHelper.WhatShouldInclude(ITServiceInclude.Parent));
             @params.AddOrReplace("selectDependencies", includeHelper.WhatShouldInclude(ITServiceInclude.Dependencies));
             @params.AddOrReplace("selectParentDependencies", includeHelper.WhatShouldInclude(ITServiceInclude.ParentDependencies));

--- a/src/ZabbixApi/Services/IconMapService.cs
+++ b/src/ZabbixApi/Services/IconMapService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectMappings", includeHelper.WhatShouldInclude(IconMapInclude.Mappings));
 
             @params.AddOrReplace("filter", filter);

--- a/src/ZabbixApi/Services/ImageService.cs
+++ b/src/ZabbixApi/Services/ImageService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
 
             @params.AddOrReplace("filter", filter);
             

--- a/src/ZabbixApi/Services/ItemPrototypeService.cs
+++ b/src/ZabbixApi/Services/ItemPrototypeService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectApplications", includeHelper.WhatShouldInclude(ItemPrototypeInclude.Applications));
             @params.AddOrReplace("selectDiscoveryRule", includeHelper.WhatShouldInclude(ItemPrototypeInclude.DiscoveryRule));
             @params.AddOrReplace("selectGraphs", includeHelper.WhatShouldInclude(ItemPrototypeInclude.Graphs));

--- a/src/ZabbixApi/Services/ItemService.cs
+++ b/src/ZabbixApi/Services/ItemService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(ItemInclude.Hosts));
             @params.AddOrReplace("selectInterfaces", includeHelper.WhatShouldInclude(ItemInclude.Interfaces));
             @params.AddOrReplace("selectTriggers", includeHelper.WhatShouldInclude(ItemInclude.Triggers));

--- a/src/ZabbixApi/Services/LLDRuleService.cs
+++ b/src/ZabbixApi/Services/LLDRuleService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(LLDRuleInclude.Hosts));
             @params.AddOrReplace("selectGraphs", includeHelper.WhatShouldInclude(LLDRuleInclude.Graphs));
             @params.AddOrReplace("selectHostPrototypes", includeHelper.WhatShouldInclude(LLDRuleInclude.HostPrototypes));

--- a/src/ZabbixApi/Services/MaintenanceService.cs
+++ b/src/ZabbixApi/Services/MaintenanceService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectGroups", includeHelper.WhatShouldInclude(MaintenanceInclude.Groups));
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(MaintenanceInclude.Hosts));
             @params.AddOrReplace("selectTimeperiods", includeHelper.WhatShouldInclude(MaintenanceInclude.TimePeriods));

--- a/src/ZabbixApi/Services/MapService.cs
+++ b/src/ZabbixApi/Services/MapService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("expandUrls", includeHelper.WhatShouldInclude(MapInclude.ExpandUrls) != null);
             @params.AddOrReplace("selectIconMap", includeHelper.WhatShouldInclude(MapInclude.IconMap));
             @params.AddOrReplace("selectLinks", includeHelper.WhatShouldInclude(MapInclude.Links));

--- a/src/ZabbixApi/Services/MediaService.cs
+++ b/src/ZabbixApi/Services/MediaService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
 
             @params.AddOrReplace("filter", filter);
             

--- a/src/ZabbixApi/Services/MediaTypeService.cs
+++ b/src/ZabbixApi/Services/MediaTypeService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectUsers", includeHelper.WhatShouldInclude(MediaTypeInclude.Users));
 
             @params.AddOrReplace("filter", filter);

--- a/src/ZabbixApi/Services/ProxyService.cs
+++ b/src/ZabbixApi/Services/ProxyService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(ProxyInclude.Hosts));
             @params.AddOrReplace("selectInterface", includeHelper.WhatShouldInclude(ProxyInclude.Interface));
 

--- a/src/ZabbixApi/Services/ScreenItemService.cs
+++ b/src/ZabbixApi/Services/ScreenItemService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
 
             @params.AddOrReplace("filter", filter);
             

--- a/src/ZabbixApi/Services/ScreenService.cs
+++ b/src/ZabbixApi/Services/ScreenService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectScreenItems", includeHelper.WhatShouldInclude(ScreenInclude.ScreenItems));
 
             @params.AddOrReplace("filter", filter);

--- a/src/ZabbixApi/Services/ScriptService.cs
+++ b/src/ZabbixApi/Services/ScriptService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectGroups", includeHelper.WhatShouldInclude(ScriptInclude.Groups));
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(ScriptInclude.Hosts));
 

--- a/src/ZabbixApi/Services/TemplateScreenItemService.cs
+++ b/src/ZabbixApi/Services/TemplateScreenItemService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
 
             @params.AddOrReplace("filter", filter);
             

--- a/src/ZabbixApi/Services/TemplateScreenService.cs
+++ b/src/ZabbixApi/Services/TemplateScreenService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectScreenItems", includeHelper.WhatShouldInclude(TemplateScreenInclude.ScreenItems));
 
             @params.AddOrReplace("filter", filter);

--- a/src/ZabbixApi/Services/TemplateService.cs
+++ b/src/ZabbixApi/Services/TemplateService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectGroups", includeHelper.WhatShouldInclude(TemplateInclude.Groups));
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(TemplateInclude.Hosts));
             @params.AddOrReplace("selectTemplates", includeHelper.WhatShouldInclude(TemplateInclude.Templates));

--- a/src/ZabbixApi/Services/TriggerPrototypeService.cs
+++ b/src/ZabbixApi/Services/TriggerPrototypeService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("expandData", includeHelper.WhatShouldInclude(TriggerPrototypeInclude.expandData) != null);
             @params.AddOrReplace("expandExpression", includeHelper.WhatShouldInclude(TriggerPrototypeInclude.expandExpression) != null);
             @params.AddOrReplace("selectGroups", includeHelper.WhatShouldInclude(TriggerPrototypeInclude.Groups));

--- a/src/ZabbixApi/Services/TriggerService.cs
+++ b/src/ZabbixApi/Services/TriggerService.cs
@@ -25,7 +25,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("expandData", includeHelper.WhatShouldInclude(TriggerInclude.expandData) != null);
             @params.AddOrReplace("expandComment", includeHelper.WhatShouldInclude(TriggerInclude.expandComment) != null);
             @params.AddOrReplace("expandDescription", includeHelper.WhatShouldInclude(TriggerInclude.expandDescription) != null);

--- a/src/ZabbixApi/Services/UserGroupService.cs
+++ b/src/ZabbixApi/Services/UserGroupService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectUsers", includeHelper.WhatShouldInclude(UserGroupInclude.Users));
 
             @params.AddOrReplace("filter", filter);

--- a/src/ZabbixApi/Services/UserlMacroService.cs
+++ b/src/ZabbixApi/Services/UserlMacroService.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("globalmacro", true);
             
             @params.AddOrReplace("filter", filter);
@@ -54,7 +54,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("selectGroups", includeHelper.WhatShouldInclude(HostMacroInclude.Groups));
             @params.AddOrReplace("selectHosts", includeHelper.WhatShouldInclude(HostMacroInclude.Hosts));
             @params.AddOrReplace("selectTemplates", includeHelper.WhatShouldInclude(HostMacroInclude.Templates));

--- a/src/ZabbixApi/Services/Userservice.cs
+++ b/src/ZabbixApi/Services/Userservice.cs
@@ -24,7 +24,7 @@ namespace ZabbixApi.Services
             if(@params == null)
                 @params = new Dictionary<string, object>();
 
-            @params.AddOrReplace("output", "extend");
+            @params.AddIfNotExist("output", "extend");
             @params.AddOrReplace("getAccess", includeHelper.WhatShouldInclude(UserInclude.Access) != null);
             @params.AddOrReplace("selectMedias", includeHelper.WhatShouldInclude(UserInclude.Medias));
             @params.AddOrReplace("selectMediatypes", includeHelper.WhatShouldInclude(UserInclude.MediaTypes));


### PR DESCRIPTION
In Zabbix php Code, inventory_mode is hosts's fields. please view line 72 on hosts.php .

When I used the lib to create host and set inventory_mode through HostInventory, the zabbix said 'Incorrect inventory field "inventory_mode". - code:-32602'.
Read the Zabbix Code (2.4.7), I find that inventory_mode has remove hosts.
and in json api's code about host we must set inventory_mode first.

if (isset($host['inventory']) && !empty($host['inventory'])) {
if (isset($host['inventory_mode']) && $host['inventory_mode'] == HOST_INVENTORY_DISABLED) {
self::exception(ZBX_API_ERROR_PARAMETERS, _('Cannot set inventory fields for disabled inventory.'));
}

            $fields = array_keys($host['inventory']);
            foreach ($fields as $field) {
                if (!in_array($field, $inventoryFields)) {
                    self::exception(ZBX_API_ERROR_PARAMETERS, _s('Incorrect inventory field "%s".', $field));
                }
            }
        }