### PR TITLE
.Net Standard 2.0 version of the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,26 @@
-# ZabbixApi
+# ZabbixApi [![NuGet](https://img.shields.io/nuget/v/Zabbix.svg)](https://www.nuget.org/packages/Zabbix)
+
 C# Zabbix Api to retrieve and modify the configuration of Zabbix
 
-# Overview
+## Overview
+
 This library allows you to make CRUD operations using Zabbix API.
 You just need to instantiate the context and the service that you want and call the operation.Like that:
 
-# Installing package
+## Installing package
+
 On the Package Manager Cosole type this to install:
-```
+
+```powershell
 Install-Package Zabbix
 ```
 
-# Configuring
-
-Ajust the parameters on the config file:
-
-```xml
-<configuration>
-  <appSettings>
-    <add key="ZabbixApi.url" value="http://myZabbixServer/zabbix/api_jsonrpc.php" />
-    <add key="ZabbixApi.user" value="Admin" />
-    <add key="ZabbixApi.password" value="zabbix" />
-  </appSettings>
-</configuration>
-```
-
-# Using
+## Using
 
 Instantiate the context and the service that you want and call the operation:
 
 ```csharp
-using(var context = new Context())
+using(var context = new Context(url, user, password))
 {
   var service = new HostService(context);
   var host = service.GetByName("myHost");
@@ -40,7 +30,7 @@ using(var context = new Context())
 You can make your own query too, like that:
 
 ```csharp
-using(var context = new Context())
+using(var context = new Context(url, user, password))
 {
   var service = new HostService(context);
   var host = service.Get(new {
@@ -52,7 +42,7 @@ using(var context = new Context())
 Or that:
 
 ```csharp
-using (var context = new Context())
+using (var context = new Context(url, user, password))
 {
     var service = new HostService(context);
     var host2 = service.Get(new
@@ -61,3 +51,28 @@ using (var context = new Context())
     });
 }
 ```
+
+## Configuring via the `.config` file
+
+Instead of specifying the configuration in the constructor the `.config` file can be used like that:
+
+```xml
+<configuration>
+  <appSettings>
+    <add key="ZabbixApi.url" value="http://myZabbixServer/zabbix/api_jsonrpc.php" />
+    <add key="ZabbixApi.user" value="Admin" />
+    <add key="ZabbixApi.password" value="zabbix" />
+  </appSettings>
+</configuration>
+```
+
+The empty constructor can then be used:
+
+```csharp
+using(var context = new Context())
+{
+  // ...
+}
+```
+
+⚠️ *Only available on the Full .Net Framework, the .Net Standard version of the library doesn't have this constructor.*

--- a/ZabbixApi/IContext.cs
+++ b/ZabbixApi/IContext.cs
@@ -26,6 +26,7 @@ namespace ZabbixApi
       //  private static IConfigurationRoot Configuration { get; set; }
         private WebClient _webClient;
 
+#if !NETSTANDARD2_0
         public Context()
         {
             var url = ConfigurationManager.AppSettings["ZabbixApi.url"];
@@ -34,6 +35,7 @@ namespace ZabbixApi
 
             Initialize(url, user, password);
         }
+#endif
         
         public Context(string url, string user, string password)
         {

--- a/ZabbixApi/ZabbixApi.csproj
+++ b/ZabbixApi/ZabbixApi.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
-	<PackageId>Zabbix</PackageId>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <PackageId>Zabbix</PackageId>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>Henrique Caires</Authors>
     <PackageTags>Zabbix ZabbixApi</PackageTags>
@@ -19,8 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Configuration" />
+    <Reference Include="System.Configuration" Condition="'$(TargetFramework)' != 'netstandard2.0'" />
   </ItemGroup>
-
 
 </Project>


### PR DESCRIPTION
This implement the very minimum changes for a netstandard2.0 version of the library.

I removed the configuration manager feature here as it would draw a lot of complexity and heavy dependencies for a very small gain. 