### PR TITLE
Add an async version of all API

### DIFF
--- a/ZabbixApi/Helper/Check.cs
+++ b/ZabbixApi/Helper/Check.cs
@@ -8,7 +8,7 @@ using ZabbixApi.Entities;
 
 namespace ZabbixApi.Helper
 {
-    public class Check
+    internal class Check
     {
         public static void NotNull(object value, string name = null)
         {

--- a/ZabbixApi/Helper/Converters.cs
+++ b/ZabbixApi/Helper/Converters.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace ZabbixApi.Helper
 {
-    public class TimestampToDateTimeConverter : JsonConverter
+    internal class TimestampToDateTimeConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -26,7 +26,7 @@ namespace ZabbixApi.Helper
         }
     }
 
-    public class IntToBoolConverter : JsonConverter
+    internal class IntToBoolConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -46,7 +46,7 @@ namespace ZabbixApi.Helper
         }
     }
 
-    public class SingleObjectConverter<T> : JsonConverter
+    internal class SingleObjectConverter<T> : JsonConverter
     {
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {

--- a/ZabbixApi/Helper/DateTimeExtensions.cs
+++ b/ZabbixApi/Helper/DateTimeExtensions.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ZabbixApi.Helper
 {
-    public static class DateTimeExtensions
+    internal static class DateTimeExtensions
     {
         public static long ToTimestamp(this DateTime dateTime)
         {

--- a/ZabbixApi/Helper/DictionaryExtensions.cs
+++ b/ZabbixApi/Helper/DictionaryExtensions.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ZabbixApi.Helper
 {
-    public static class DictionaryExtensions
+    internal static class DictionaryExtensions
     {
         public static void AddIfNotExist<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
         {

--- a/ZabbixApi/IContext.cs
+++ b/ZabbixApi/IContext.cs
@@ -2,29 +2,42 @@
 using ZabbixApi.Helper;
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Net;
 using System.Text;
-using System.IO;
 using System.Configuration;
-
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
 
 namespace ZabbixApi
 {
     public interface IContext : IDisposable
     {
         T SendRequest<T>(object @params, string method);
+        Task<T> SendRequestAsync<T>(object @params, string method);
+
+        void Authenticate(string user, string password);
+        Task AuthenticateAsync(string user, string password);
     }
 
     public class Context : IContext
     {
         private string _url;
-        private string _user;
-        private string _password;
 
-        private string _authenticationToken;
-      //  private static IConfigurationRoot Configuration { get; set; }
+        private volatile string _authenticationToken;
         private WebClient _webClient;
+        private HttpClient _httpClient;
+
+        private static readonly JsonSerializerSettings _serializerSettings;
+
+        static Context()
+        {
+            _serializerSettings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                Converters = new JsonConverter[] { new Newtonsoft.Json.Converters.JavaScriptDateTimeConverter() }
+            };
+        }
 
         public Context()
         {
@@ -32,79 +45,134 @@ namespace ZabbixApi
             var user = ConfigurationManager.AppSettings["ZabbixApi.user"];
             var password = ConfigurationManager.AppSettings["ZabbixApi.password"];
 
-            Initialize(url, user, password);
+            Initialize(url);
+            Authenticate(user, password);
         }
         
+        public Context(string url)
+        {
+            Initialize(url);
+        }
+
         public Context(string url, string user, string password)
+            : this(url)
         {
-            Initialize(url, user, password);
+            Authenticate(user, password);
         }
 
-        private void Initialize(string url, string user, string password)
+        private void Initialize(string url)
         {
+            Check.IsNotNullOrWhiteSpace(url, "ZabbixApi.url");
+
             _url = url;
-            _user = user;
-            _password = password;
-
-            Check.IsNotNullOrWhiteSpace(_url, "ZabbixApi.url");
-            Check.IsNotNullOrWhiteSpace(_user, "ZabbixApi.user");
-            Check.IsNotNullOrWhiteSpace(_password, "ZabbixApi.password");
-
             _webClient = new WebClient();
-
-            Authenticate();
+            _httpClient = new HttpClient();
         }
         
-        private void Authenticate()
+        public void Authenticate(string user, string password)
         {
-            var request = new Request();
-            request.method = "user.login";
-            request.@params = new Dictionary<string, string>() { { "user", _user }, { "password", _password } };
-            //request.id = 1;
-            var values = new NameValueCollection();
-            values.Add("content-type", "application/json-rpc");
-            _webClient.Headers.Add(values);
+            Check.IsNotNullOrWhiteSpace(user, "ZabbixApi.user");
+            Check.IsNotNullOrWhiteSpace(password, "ZabbixApi.password");
 
-            var responseData = _webClient.UploadData(_url, Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(request)));
-            var responseString = Encoding.UTF8.GetString(responseData);
+            lock (_webClient)
+            {
+                _authenticationToken = SendRequest<string>(
+                    new Dictionary<string, string> {{"user", user}, {"password", password}},
+                    "user.login",
+                    null);
+            }
+        }
 
-            _authenticationToken = JsonConvert.DeserializeObject<Response<string>>(responseString).result.ToString();
+        public async Task AuthenticateAsync(string user, string password)
+        {
+            Check.IsNotNullOrWhiteSpace(user, "ZabbixApi.user");
+            Check.IsNotNullOrWhiteSpace(password, "ZabbixApi.password");
+
+            _authenticationToken = await SendRequestAsync<string>(
+                new Dictionary<string, string> {{"user", user}, {"password", password}},
+                "user.login",
+                null);
         }
 
         T IContext.SendRequest<T>(object @params, string method)
         {
             lock(_webClient)
             {
-                var id = new Random(DateTime.Now.Millisecond).Next();
-                var request = new Request();
-                request.method = method;
-                request.@params = @params;
-                request.id = id;
-                request.auth = _authenticationToken;
-
-                var values = new NameValueCollection();
-                values.Add("content-type", "application/json-rpc");
-                _webClient.Headers.Add(values);
-                
-                var settings = new JsonSerializerSettings();
-                settings.NullValueHandling = NullValueHandling.Ignore;
-                settings.Converters = new JsonConverter[] { new Newtonsoft.Json.Converters.JavaScriptDateTimeConverter() };
-                
-                var responseData = _webClient.UploadData(_url, Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(request, settings)));
-                var responseString = Encoding.UTF8.GetString(responseData);
-
-                var response = JsonConvert.DeserializeObject<Response<T>>(responseString, settings);
-
-                if (response.error != null)
-                {
-                    throw new Exception(response.error.message, new Exception(string.Format("{0} - code:{1}", response.error.data, response.error.code)));
-                }
-
-                if (response.id != id)
-                    throw new Exception(string.Format("O Id do response ({0}) não corresponde ao id do request ({1})", response.id, id));
-
-                return response.result;
+                var token = CheckAndGetToken();
+                return SendRequest<T>(@params, method, token);
             }
+        }
+
+        private T SendRequest<T>(object @params, string method, string token)
+        {
+            lock(_webClient)
+            {
+                var request = GetRequest(@params, method, token);
+                
+                _webClient.Headers.Add("content-type", "application/json-rpc");
+                var responseData = _webClient.UploadData(_url, Serialize(request));
+                return HandleResponse<T>(request.id, responseData);
+            }
+        }
+
+        private string CheckAndGetToken()
+        {
+            var token = _authenticationToken;
+            if (token == null)
+            {
+                throw new InvalidOperationException("This zabbix context isn't authenticated.");
+            }
+
+            return token;
+        }
+
+        async Task<T> IContext.SendRequestAsync<T>(object @params, string method)
+        {
+            var token = CheckAndGetToken();
+            return await SendRequestAsync<T>(@params, method, token);
+        }
+
+        private async Task<T> SendRequestAsync<T>(object @params, string method, string token)
+        {
+            var request = GetRequest(@params, method, token);
+            var content = new ByteArrayContent(Serialize(request));
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json-rpc");
+
+            var response = await _httpClient.PostAsync(_url, content);
+            var responseData = await response.Content.ReadAsByteArrayAsync();
+            return HandleResponse<T>(request.id, responseData);
+        }
+
+        private static T HandleResponse<T>(string requestId, byte[] responseData)
+        {
+            var responseString = Encoding.UTF8.GetString(responseData);
+            var response = JsonConvert.DeserializeObject<Response<T>>(responseString, _serializerSettings);
+
+            if (response.error != null)
+            {
+                throw new Exception(response.error.message, new Exception(string.Format("{0} - code:{1}", response.error.data, response.error.code)));
+            }
+
+            if (response.id != requestId)
+                throw new Exception(string.Format("O Id do response ({0}) não corresponde ao id do request ({1})", response.id, requestId));
+
+            return response.result;
+        }
+
+        private static byte[] Serialize<T>(T value)
+        {
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(value, _serializerSettings));
+        }
+
+        private static Request GetRequest(object @params, string method, string authenticationToken)
+        {
+            return new Request
+            {
+                method = method,
+                @params = @params,
+                id = Guid.NewGuid().ToString(),
+                auth = authenticationToken
+            };
         }
 
         private class Request
@@ -112,7 +180,7 @@ namespace ZabbixApi
             public string jsonrpc  { get; set; }
             public string method { get; set; }
             public object @params { get; set; }
-            public int id { get; set; }
+            public string id { get; set; }
             public string auth { get; set; }
 
             public Request()
@@ -126,7 +194,7 @@ namespace ZabbixApi
             public string jsonrpc { get; set; }
             public T result { get; set; }
             public Error error { get; set; }
-            public int id { get; set; }
+            public string id { get; set; }
         }
 
         private class Error
@@ -143,20 +211,15 @@ namespace ZabbixApi
             GC.SuppressFinalize(this);
         }
 
-        ~Context()
-        {
-            Dispose(false);
-        }
-
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)
             {
-                if (_webClient != null)
-                {
-                    _webClient.Dispose();
-                    _webClient = null;
-                }
+                _webClient?.Dispose();
+                _webClient = null;
+
+                _httpClient?.Dispose();
+                _httpClient = null;
             }
         }
         #endregion

--- a/ZabbixApi/Services/ActionService.cs
+++ b/ZabbixApi/Services/ActionService.cs
@@ -17,7 +17,7 @@ namespace ZabbixApi.Services
     {
         public ActionService(IContext context) : base(context, "action") { }
 
-        public override IEnumerable<Entities.Action> Get(object filter = null, IEnumerable<ActionInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<ActionInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
 
@@ -29,8 +29,8 @@ namespace ZabbixApi.Services
             @params.AddOrReplace("selectOperations", includeHelper.WhatShouldInclude(ActionInclude.Operations));
 
             @params.AddOrReplace("filter", filter);
-                    
-            return BaseGet(@params);
+
+            return @params;
         }
 
         public class ActionsidsResult : EntityResultBase

--- a/ZabbixApi/Services/AlertService.cs
+++ b/ZabbixApi/Services/AlertService.cs
@@ -14,11 +14,11 @@ namespace ZabbixApi.Services
         IEnumerable<Alert> Get(object filter = null, IEnumerable<AlertInclude> include = null, Dictionary<string, object> @params = null);
     }
 
-    public class AlertService : ServiceBase<Alert>, IAlertService
+    public class AlertService : ServiceBase<Alert, AlertInclude>, IAlertService
     {
         public AlertService(IContext context) : base(context, "alert") { }
 
-        public IEnumerable<Alert> Get(object filter = null, IEnumerable<AlertInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<AlertInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -31,7 +31,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
     }
 

--- a/ZabbixApi/Services/ApiInfoService.cs
+++ b/ZabbixApi/Services/ApiInfoService.cs
@@ -22,5 +22,13 @@ namespace ZabbixApi.Services
                     "apiinfo.version"
                     );
         }
+
+        public async Task<string> GetVersionAsync()
+        {
+            return await _context.SendRequestAsync<string>(
+                null,
+                "apiinfo.version"
+            );
+        }
     }
 }

--- a/ZabbixApi/Services/ApplicationService.cs
+++ b/ZabbixApi/Services/ApplicationService.cs
@@ -16,7 +16,7 @@ namespace ZabbixApi.Services
     {
         public ApplicationService(IContext context) : base(context, "application") { }
 
-        public override IEnumerable<Application> Get(object filter = null, IEnumerable<ApplicationInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<ApplicationInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -28,7 +28,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class ApplicationsidsResult : EntityResultBase

--- a/ZabbixApi/Services/DiscoveredHostService.cs
+++ b/ZabbixApi/Services/DiscoveredHostService.cs
@@ -14,11 +14,11 @@ namespace ZabbixApi.Services
         IEnumerable<DiscoveredHost> Get(object filter = null, IEnumerable<DiscoveredHostInclude> include = null, Dictionary<string, object> @params = null);
     }
 
-    public class DiscoveredHostService : ServiceBase<DiscoveredHost>, IDiscoveredHostService
+    public class DiscoveredHostService : ServiceBase<DiscoveredHost, DiscoveredHostInclude>, IDiscoveredHostService
     {
         public DiscoveredHostService(IContext context) : base(context, "dhost") { }
 
-        public IEnumerable<DiscoveredHost> Get(object filter = null, IEnumerable<DiscoveredHostInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<DiscoveredHostInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -30,7 +30,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
     }
 

--- a/ZabbixApi/Services/DiscoveredServiceService.cs
+++ b/ZabbixApi/Services/DiscoveredServiceService.cs
@@ -14,11 +14,11 @@ namespace ZabbixApi.Services
         IEnumerable<DiscoveredService> Get(object filter = null, IEnumerable<DiscoveredServiceInclude> include = null, Dictionary<string, object> @params = null);
     }
 
-    public class DiscoveredServiceService : ServiceBase<DiscoveredService>, IDiscoveredServiceService
+    public class DiscoveredServiceService : ServiceBase<DiscoveredService, DiscoveredServiceInclude>, IDiscoveredServiceService
     {
         public DiscoveredServiceService(IContext context) : base(context, "dservice") { }
 
-        public IEnumerable<DiscoveredService> Get(object filter = null, IEnumerable<DiscoveredServiceInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<DiscoveredServiceInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -31,7 +31,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
     }
 

--- a/ZabbixApi/Services/DiscoveryCheckService.cs
+++ b/ZabbixApi/Services/DiscoveryCheckService.cs
@@ -14,11 +14,11 @@ namespace ZabbixApi.Services
         IEnumerable<DiscoveryCheck> Get(object filter = null, IEnumerable<DiscoveryCheckInclude> include = null, Dictionary<string, object> @params = null);
     }
 
-    public class DiscoveryCheckService : ServiceBase<DiscoveryCheck>, IDiscoveryCheckService
+    public class DiscoveryCheckService : ServiceBase<DiscoveryCheck, DiscoveryCheckInclude>, IDiscoveryCheckService
     {
         public DiscoveryCheckService(IContext context) : base(context, "dcheck") { }
 
-        public IEnumerable<DiscoveryCheck> Get(object filter = null, IEnumerable<DiscoveryCheckInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<DiscoveryCheckInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -28,7 +28,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
     }
 

--- a/ZabbixApi/Services/DiscoveryRuleService.cs
+++ b/ZabbixApi/Services/DiscoveryRuleService.cs
@@ -18,7 +18,7 @@ namespace ZabbixApi.Services
     {
         public DiscoveryRuleService(IContext context) : base(context, "drule") { }
 
-        public override IEnumerable<DiscoveryRule> Get(object filter = null, IEnumerable<DiscoveryRuleInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<DiscoveryRuleInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -30,7 +30,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class DiscoveryRulesidsResult : EntityResultBase

--- a/ZabbixApi/Services/GraphItemService.cs
+++ b/ZabbixApi/Services/GraphItemService.cs
@@ -14,11 +14,11 @@ namespace ZabbixApi.Services
         IEnumerable<GraphItem> Get(object filter = null, IEnumerable<GraphItemInclude> include = null, Dictionary<string, object> @params = null);
     }
 
-    public class GraphItemService : ServiceBase<GraphItem>, IGraphItemService
+    public class GraphItemService : ServiceBase<GraphItem, GraphItemInclude>, IGraphItemService
     {
         public GraphItemService(IContext context) : base(context, "graphitem") { }
 
-        public IEnumerable<GraphItem> Get(object filter = null, IEnumerable<GraphItemInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<GraphItemInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -29,7 +29,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
     }
 

--- a/ZabbixApi/Services/GraphPrototypeService.cs
+++ b/ZabbixApi/Services/GraphPrototypeService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public GraphPrototypeService(IContext context) : base(context, "graphprototype") { }
 
-        public override IEnumerable<GraphPrototype> Get(object filter = null, IEnumerable<GraphPrototypeInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<GraphPrototypeInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -35,7 +35,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class GraphPrototypesidsResult : EntityResultBase

--- a/ZabbixApi/Services/GraphService.cs
+++ b/ZabbixApi/Services/GraphService.cs
@@ -18,7 +18,7 @@ namespace ZabbixApi.Services
     {
         public GraphService(IContext context) : base(context, "graph") { }
 
-        public override IEnumerable<Graph> Get(object filter = null, IEnumerable<GraphInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<GraphInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -34,7 +34,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class GraphsidsResult : EntityResultBase

--- a/ZabbixApi/Services/HistoryService.cs
+++ b/ZabbixApi/Services/HistoryService.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using ZabbixApi.Entities;
 using ZabbixApi.Helper;
-using ZabbixApi;
 
 namespace ZabbixApi.Services
 {
@@ -18,30 +16,46 @@ namespace ZabbixApi.Services
         IEnumerable<History> GetFromByType(DateTime from, IEnumerable<History.HistoryType> historyTypes, object filter = null, Dictionary<string, object> @params = null);
         IEnumerable<History> GetTextFrom(DateTime from, object filter = null, Dictionary<string, object> @params = null);
         IEnumerable<History> GetNumericFrom(DateTime from, object filter = null, Dictionary<string, object> @params = null);
+        
+        Task<IReadOnlyList<History>> GetByTypeAsync(History.HistoryType historyType, object filter = null, Dictionary<string, object> @params = null);
+        Task<IReadOnlyList<History>> GetFromByTypeAsync(DateTime from, History.HistoryType historyType, object filter = null, Dictionary<string, object> @params = null);
+        Task<IReadOnlyList<History>> GetByTypeAsync(IEnumerable<History.HistoryType> historyTypes, object filter = null, Dictionary<string, object> @params = null);
+        Task<IReadOnlyList<History>> GetFromByTypeAsync(DateTime from, IEnumerable<History.HistoryType> historyTypes, object filter = null, Dictionary<string, object> @params = null);
+        IEnumerable<History> GetTextFromAsync(DateTime from, object filter = null, Dictionary<string, object> @params = null);
+        Task<IReadOnlyList<History>> GetNumericFromAsync(DateTime from, object filter = null, Dictionary<string, object> @params = null);
     }
 
-    public class HistoryService : ServiceBase<History>, IHistoryService
+    public class HistoryService : ServiceBase<History, HistoryInclude>, IHistoryService
     {
+        private static readonly History.HistoryType[] _textHistoryTypes =
+        { 
+            History.HistoryType.LogType, 
+            History.HistoryType.StringType, 
+            History.HistoryType.TextType
+        };
+
+        private static readonly History.HistoryType[] _numericHistoryTypes =
+        { 
+            History.HistoryType.FloatType, 
+            History.HistoryType.IntegerType
+        };
+
         public HistoryService(IContext context) : base(context, "history") { }
 
-        public IEnumerable<History> Get(object filter = null, IEnumerable<HistoryInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<HistoryInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
-            if (@params == null)
-                @params = new Dictionary<string, object>();
 
+            @params = @params ?? new Dictionary<string, object>();
             @params.AddIfNotExist("output", "extend");
-
             @params.AddOrReplace("filter", filter);
 
-            return BaseGet(@params);
+            return @params;
         }
 
         public IEnumerable<History> GetByType(History.HistoryType historyType, object filter = null, Dictionary<string, object> @params = null)
         {
-            if (@params == null)
-                @params = new Dictionary<string, object>();
-
+            @params = @params ?? new Dictionary<string, object>();
             @params.AddOrReplace("history", historyType);
 
             var histories = Get(filter: filter, @params: @params);
@@ -53,14 +67,35 @@ namespace ZabbixApi.Services
             }
         }
 
+        public async Task<IReadOnlyList<History>> GetByTypeAsync(History.HistoryType historyType, object filter = null, Dictionary<string, object> @params = null)
+        {
+            @params = @params ?? new Dictionary<string, object>();
+            @params.AddOrReplace("history", historyType);
+
+            var histories = await GetAsync(filter: filter, @params: @params);
+
+            foreach (var history in histories)
+            {
+                history.historyType = historyType;
+            }
+
+            return histories;
+        }
+
         public IEnumerable<History> GetFromByType(DateTime from, History.HistoryType historyType, object filter = null, Dictionary<string, object> @params = null)
         {
-            if (@params == null)
-                @params = new Dictionary<string, object>();
-
+            @params = @params ?? new Dictionary<string, object>();
             @params.AddOrReplace("time_from", from.ToTimestamp());
 
             return GetByType(historyType: historyType, filter: filter, @params: @params);
+        }
+
+        public async Task<IReadOnlyList<History>> GetFromByTypeAsync(DateTime from, History.HistoryType historyType, object filter = null, Dictionary<string, object> @params = null)
+        {
+            @params = @params ?? new Dictionary<string, object>();
+            @params.AddOrReplace("time_from", from.ToTimestamp());
+
+            return await GetByTypeAsync(historyType: historyType, filter: filter, @params: @params);
         }
 
         public IEnumerable<History> GetByType(IEnumerable<History.HistoryType> historyTypes, object filter = null, Dictionary<string, object> @params = null)
@@ -68,38 +103,71 @@ namespace ZabbixApi.Services
             return historyTypes.SelectMany(h => GetByType(historyType: h, filter: filter, @params: @params));
         }
 
+        public async Task<IReadOnlyList<History>> GetByTypeAsync(IEnumerable<History.HistoryType> historyTypes, object filter = null, Dictionary<string, object> @params = null)
+        {
+            var result = new List<History>();
+            foreach (var historyType in historyTypes)
+            {
+                var values = await GetByTypeAsync(historyType: historyType, filter: filter, @params: @params);
+                result.AddRange(values);
+            }
+            return result;
+        }
+
         public IEnumerable<History> GetFromByType(DateTime from, IEnumerable<History.HistoryType> historyTypes, object filter = null, Dictionary<string, object> @params = null)
         {
             return historyTypes.SelectMany(h => GetFromByType(from: from, historyType: h, filter: filter, @params: @params));
+        }
+
+        public async Task<IReadOnlyList<History>> GetFromByTypeAsync(DateTime from, IEnumerable<History.HistoryType> historyTypes, object filter = null, Dictionary<string, object> @params = null)
+        {
+            var result = new List<History>();
+            foreach (var historyType in historyTypes)
+            {
+                var values = await GetFromByTypeAsync(from: from, historyType: historyType, filter: filter, @params: @params);
+                result.AddRange(values);
+            }
+            return result;
         }
 
         public IEnumerable<History> GetTextFrom(DateTime from, object filter = null, Dictionary<string, object> @params = null)
         {
             return GetFromByType(
                     from: from, 
-                    historyTypes: new History.HistoryType[] 
-                    { 
-                        History.HistoryType.LogType, 
-                        History.HistoryType.StringType, 
-                        History.HistoryType.TextType
-                    }, 
+                    historyTypes: _textHistoryTypes, 
                     filter: filter, 
                     @params: @params
                 );
+        }
+
+        public IEnumerable<History> GetTextFromAsync(DateTime from, object filter = null, Dictionary<string, object> @params = null)
+        {
+            return GetFromByType(
+                from: from, 
+                historyTypes: _textHistoryTypes, 
+                filter: filter, 
+                @params: @params
+            );
         }
 
         public IEnumerable<History> GetNumericFrom(DateTime from, object filter = null, Dictionary<string, object> @params = null)
         {
             return GetFromByType(
                     from: from,
-                    historyTypes: new History.HistoryType[] 
-                    { 
-                        History.HistoryType.FloatType, 
-                        History.HistoryType.IntegerType
-                    },
+                    historyTypes: _numericHistoryTypes,
                     filter: filter,
                     @params: @params
                 );
+        }
+
+        public async Task<IReadOnlyList<History>> GetNumericFromAsync(DateTime from, object filter = null, Dictionary<string, object> @params = null)
+        {
+            return await GetFromByTypeAsync(
+                from: from,
+                historyTypes: _numericHistoryTypes,
+                filter: filter,
+                @params: @params
+            );
         }
     }
 

--- a/ZabbixApi/Services/HostGroupService.cs
+++ b/ZabbixApi/Services/HostGroupService.cs
@@ -1,11 +1,8 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using ZabbixApi.Helper;
-using ZabbixApi;
 using ZabbixApi.Entities;
 
 namespace ZabbixApi.Services
@@ -16,13 +13,18 @@ namespace ZabbixApi.Services
         IEnumerable<HostGroup> GetByName(List<string> names, IList<HostGroupInclude> include = null);
         HostGroup GetByName(string name, HostGroupInclude include);
         IEnumerable<HostGroup> GetByName(List<string> names, HostGroupInclude include);
+
+        Task<HostGroup> GetByNameAsync(string name, IList<HostGroupInclude> include = null);
+        Task<IReadOnlyList<HostGroup>> GetByNameAsync(List<string> names, IList<HostGroupInclude> include = null);
+        Task<HostGroup> GetByNameAsync(string name, HostGroupInclude include);
+        Task<IReadOnlyList<HostGroup>> GetByNameAsync(List<string> names, HostGroupInclude include);
     }
 
     public class HostGroupService : CRUDService<HostGroup, HostGroupService.HostGroupsidsResult, HostGroupInclude>, IHostGroupService
     {
         public HostGroupService(IContext context) : base(context, "hostgroup") { }
 
-        public override IEnumerable<HostGroup> Get(object filter = null, IEnumerable<HostGroupInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<HostGroupInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -36,7 +38,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class HostGroupsidsResult : EntityResultBase
@@ -48,9 +50,17 @@ namespace ZabbixApi.Services
         public HostGroup GetByName(string name, IList<HostGroupInclude> include = null)
         {
             return GetByName(
-                names: new List<string>() { name },
+                names: new List<string> { name },
                 include: include
             ).FirstOrDefault();
+        }
+
+        public async Task<HostGroup> GetByNameAsync(string name, IList<HostGroupInclude> include = null)
+        {
+            return (await GetByNameAsync(
+                names: new List<string> { name },
+                include: include
+            )).FirstOrDefault();
         }
 
         public IEnumerable<HostGroup> GetByName(List<string> names, IList<HostGroupInclude> include = null)
@@ -64,17 +74,47 @@ namespace ZabbixApi.Services
             );
         }
 
+        public async Task<IReadOnlyList<HostGroup>> GetByNameAsync(List<string> names, IList<HostGroupInclude> include = null)
+        {
+            return await GetAsync(
+                filter: new
+                {
+                    name = names
+                },
+                include: include
+            );
+        }
+
         public HostGroup GetByName(string name, HostGroupInclude include)
         {
             return GetByName(
-                names: new List<string>() { name },
+                names: new List<string> { name },
                 include: include
             ).FirstOrDefault();
+        }
+
+        public async Task<HostGroup> GetByNameAsync(string name, HostGroupInclude include)
+        {
+            return (await GetByNameAsync(
+                names: new List<string> { name },
+                include: include
+            )).FirstOrDefault();
         }
 
         public IEnumerable<HostGroup> GetByName(List<string> names, HostGroupInclude include)
         {
             return Get(
+                filter: new
+                {
+                    name = names
+                },
+                include: include
+            );
+        }
+
+        public async Task<IReadOnlyList<HostGroup>> GetByNameAsync(List<string> names, HostGroupInclude include)
+        {
+            return await GetAsync(
                 filter: new
                 {
                     name = names

--- a/ZabbixApi/Services/HostInterfaceService.cs
+++ b/ZabbixApi/Services/HostInterfaceService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public HostInterfaceService(IContext context) : base(context, "hostinterface") { }
 
-        public override IEnumerable<HostInterface> Get(object filter = null, IEnumerable<HostInterfaceInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<HostInterfaceInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -31,7 +31,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class HostInterfacesidsResult : EntityResultBase

--- a/ZabbixApi/Services/HostPrototypeService.cs
+++ b/ZabbixApi/Services/HostPrototypeService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public HostPrototypeService(IContext context) : base(context, "hostprototype") { }
 
-        public override IEnumerable<HostPrototype> Get(object filter = null, IEnumerable<HostPrototypeInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<HostPrototypeInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -35,7 +35,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class HostPrototypesidsResult : EntityResultBase

--- a/ZabbixApi/Services/HostService.cs
+++ b/ZabbixApi/Services/HostService.cs
@@ -1,12 +1,9 @@
-﻿using Newtonsoft.Json;
-using ZabbixApi.Helper;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using ZabbixApi;
+using Newtonsoft.Json;
 using ZabbixApi.Entities;
+using ZabbixApi.Helper;
 
 namespace ZabbixApi.Services
 {
@@ -14,6 +11,9 @@ namespace ZabbixApi.Services
     {
         Host GetByName(string name, IList<HostInclude> include = null);
         IEnumerable<Host> GetByName(List<string> names, IList<HostInclude> include = null);
+
+        Task<Host> GetByNameAsync(string name, IList<HostInclude> include = null);
+        Task<IReadOnlyList<Host>> GetByNameAsync(List<string> names, IList<HostInclude> include = null);
     }
 
     public class HostService : CRUDService<Host, HostService.HostidsResult, HostInclude>, IHostService
@@ -21,7 +21,7 @@ namespace ZabbixApi.Services
         public HostService(IContext context) : base(context, "host") { }
 
 
-        public override IEnumerable<Host> Get(object filter = null, IEnumerable<HostInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<HostInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
 
@@ -51,18 +51,27 @@ namespace ZabbixApi.Services
             settings.Converters = new JsonConverter[] { new Newtonsoft.Json.Converters.JavaScriptDateTimeConverter() };
             var z = JsonConvert.SerializeObject(@params, settings);
 
-            return BaseGet(@params);
+            return @params;
         }
 
         public Host GetByName(string name, IList<HostInclude> include = null)
         {
-            return GetByPropety("host", name, include);
+            return GetByProperty("host", name, include);
+        }
+
+        public async Task<Host> GetByNameAsync(string name, IList<HostInclude> include = null)
+        {
+            return await GetByPropertyAsync("host", name, include);
         }
 
         public IEnumerable<Host> GetByName(List<string> names, IList<HostInclude> include = null)
         {
-            return GetByPropety("host", names, include);
-            
+            return GetByProperty("host", names, include);
+        }
+
+        public async Task<IReadOnlyList<Host>> GetByNameAsync(List<string> names, IList<HostInclude> include = null)
+        {
+            return await GetByPropertyAsync("host", names, include);
         }
 
         public class HostidsResult : EntityResultBase

--- a/ZabbixApi/Services/IconMapService.cs
+++ b/ZabbixApi/Services/IconMapService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public IconMapService(IContext context) : base(context, "iconmap") { }
 
-        public override IEnumerable<IconMap> Get(object filter = null, IEnumerable<IconMapInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<IconMapInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -30,7 +30,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class IconMapsidsResult : EntityResultBase

--- a/ZabbixApi/Services/ImageService.cs
+++ b/ZabbixApi/Services/ImageService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public ImageService(IContext context) : base(context, "image") { }
 
-        public override IEnumerable<Image> Get(object filter = null, IEnumerable<ImageInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<ImageInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -29,7 +29,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class ImagesidsResult : EntityResultBase

--- a/ZabbixApi/Services/ItemPrototypeService.cs
+++ b/ZabbixApi/Services/ItemPrototypeService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public ItemPrototypeService(IContext context) : base(context, "itemprototype") { }
 
-        public override IEnumerable<ItemPrototype> Get(object filter = null, IEnumerable<ItemPrototypeInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<ItemPrototypeInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -34,7 +34,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class ItemPrototypesidsResult : EntityResultBase

--- a/ZabbixApi/Services/ItemService.cs
+++ b/ZabbixApi/Services/ItemService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public ItemService(IContext context) : base(context, "item") { }
 
-        public override IEnumerable<Item> Get(object filter = null, IEnumerable<ItemInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<ItemInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -36,7 +36,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class ItemsidsResult : EntityResultBase

--- a/ZabbixApi/Services/LLDRuleService.cs
+++ b/ZabbixApi/Services/LLDRuleService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public LLDRuleService(IContext context) : base(context, "discoveryrule") { }
 
-        public override IEnumerable<LLDRule> Get(object filter = null, IEnumerable<LLDRuleInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<LLDRuleInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -34,7 +34,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class LLDRulesidsResult : EntityResultBase

--- a/ZabbixApi/Services/MaintenanceService.cs
+++ b/ZabbixApi/Services/MaintenanceService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public MaintenanceService(IContext context) : base(context, "discoveryrule") { }
 
-        public override IEnumerable<Maintenance> Get(object filter = null, IEnumerable<MaintenanceInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<MaintenanceInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -32,7 +32,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class MaintenancesidsResult : EntityResultBase

--- a/ZabbixApi/Services/MapService.cs
+++ b/ZabbixApi/Services/MapService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public MapService(IContext context) : base(context, "map") { }
 
-        public override IEnumerable<Map> Get(object filter = null, IEnumerable<MapInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<MapInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -34,7 +34,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class MapsidsResult : EntityResultBase

--- a/ZabbixApi/Services/MediaService.cs
+++ b/ZabbixApi/Services/MediaService.cs
@@ -15,11 +15,11 @@ namespace ZabbixApi.Services
         IEnumerable<Media> Get(object filter = null, IEnumerable<MediaInclude> include = null, Dictionary<string, object> @params = null);
     }
 
-    public class MediaService : ServiceBase<Media>, IMediaService
+    public class MediaService : ServiceBase<Media, MediaInclude>, IMediaService
     {
         public MediaService(IContext context) : base(context, "usermedia") { }
 
-        public IEnumerable<Media> Get(object filter = null, IEnumerable<MediaInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<MediaInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -29,7 +29,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
     }
 

--- a/ZabbixApi/Services/MediaTypeService.cs
+++ b/ZabbixApi/Services/MediaTypeService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public MediaTypeService(IContext context) : base(context, "mediatype") { }
 
-        public override IEnumerable<MediaType> Get(object filter = null, IEnumerable<MediaTypeInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<MediaTypeInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -30,7 +30,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class MediaTypesidsResult : EntityResultBase

--- a/ZabbixApi/Services/ProxyService.cs
+++ b/ZabbixApi/Services/ProxyService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public ProxyService(IContext context) : base(context, "proxy") { }
 
-        public override IEnumerable<Proxy> Get(object filter = null, IEnumerable<ProxyInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<ProxyInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -31,7 +31,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class ProxysidsResult : EntityResultBase

--- a/ZabbixApi/Services/ScreenItemService.cs
+++ b/ZabbixApi/Services/ScreenItemService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public ScreenItemService(IContext context) : base(context, "screenitem") { }
 
-        public override IEnumerable<ScreenItem> Get(object filter = null, IEnumerable<ScreenItemInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<ScreenItemInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -29,7 +29,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class ScreenItemsidsResult : EntityResultBase

--- a/ZabbixApi/Services/ScreenService.cs
+++ b/ZabbixApi/Services/ScreenService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public ScreenService(IContext context) : base(context, "screen") { }
 
-        public override IEnumerable<Screen> Get(object filter = null, IEnumerable<ScreenInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<ScreenInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -30,7 +30,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class ScreensidsResult : EntityResultBase

--- a/ZabbixApi/Services/ScriptService.cs
+++ b/ZabbixApi/Services/ScriptService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public ScriptService(IContext context) : base(context, "script") { }
 
-        public override IEnumerable<Script> Get(object filter = null, IEnumerable<ScriptInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<ScriptInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -31,7 +31,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class ScriptsidsResult : EntityResultBase

--- a/ZabbixApi/Services/ServiceBase.cs
+++ b/ZabbixApi/Services/ServiceBase.cs
@@ -1,14 +1,10 @@
 ﻿using ZabbixApi.Entities;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using ZabbixApi;
 
 namespace ZabbixApi.Services
 {
-    public class ServiceBase<T> where T : EntityBase
+    public abstract class ServiceBase<TEntity, TInclude> where TEntity : EntityBase
     {
         protected IContext _context;
         protected readonly string _className;
@@ -19,13 +15,26 @@ namespace ZabbixApi.Services
             _className = className;
         }
 
-        public IEnumerable<T> BaseGet(object @params)
+        protected abstract Dictionary<string, object> BuildParams(object filter = null, IEnumerable<TInclude> include = null, Dictionary<string, object> @params = null);
+
+        public IEnumerable<TEntity> Get(object filter = null, IEnumerable<TInclude> include = null, Dictionary<string, object> @params = null)
         {
-            var resp = _context.SendRequest<T[]>(
-                    @params,
-                    _className + ".get"
-                    );
-            return resp;
+            return BaseGet(BuildParams(filter, include, @params));
+        }
+
+        public Task<IReadOnlyList<TEntity>> GetAsync(object filter = null, IEnumerable<TInclude> include = null, Dictionary<string, object> @params = null)
+        {
+            return BaseGetAsync(BuildParams(filter, include, @params));
+        }
+
+        protected IEnumerable<TEntity> BaseGet(object @params)
+        {
+            return _context.SendRequest<TEntity[]>(@params, _className + ".get");
+        }
+
+        protected async Task<IReadOnlyList<TEntity>> BaseGetAsync(object @params)
+        {
+            return await _context.SendRequestAsync<TEntity[]>(@params, _className + ".get");
         }
     }
 }

--- a/ZabbixApi/Services/TemplateScreenItemService.cs
+++ b/ZabbixApi/Services/TemplateScreenItemService.cs
@@ -14,11 +14,11 @@ namespace ZabbixApi.Services
         IEnumerable<TemplateScreenItem> Get(object filter = null, IEnumerable<TemplateScreenItemInclude> include = null, Dictionary<string, object> @params = null);
     }
 
-    public class TemplateScreenItemService : ServiceBase<TemplateScreenItem>, ITemplateScreenItemService
+    public class TemplateScreenItemService : ServiceBase<TemplateScreenItem, TemplateScreenItemInclude>, ITemplateScreenItemService
     {
         public TemplateScreenItemService(IContext context) : base(context, "templatescreenitem") { }
 
-        public IEnumerable<TemplateScreenItem> Get(object filter = null, IEnumerable<TemplateScreenItemInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<TemplateScreenItemInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -28,7 +28,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
     }
 

--- a/ZabbixApi/Services/TemplateScreenService.cs
+++ b/ZabbixApi/Services/TemplateScreenService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public TemplateScreenService(IContext context) : base(context, "templatescreen") { }
 
-        public override IEnumerable<TemplateScreen> Get(object filter = null, IEnumerable<TemplateScreenInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<TemplateScreenInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -30,7 +30,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class TemplateScreensidsResult : EntityResultBase

--- a/ZabbixApi/Services/TemplateService.cs
+++ b/ZabbixApi/Services/TemplateService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public TemplateService(IContext context) : base(context, "template") { }
 
-        public override IEnumerable<Template> Get(object filter = null, IEnumerable<TemplateInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<TemplateInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -41,7 +41,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class TemplatesidsResult : EntityResultBase

--- a/ZabbixApi/Services/TriggerPrototypeService.cs
+++ b/ZabbixApi/Services/TriggerPrototypeService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public TriggerPrototypeService(IContext context) : base(context, "triggerprototype") { }
 
-        public override IEnumerable<TriggerPrototype> Get(object filter = null, IEnumerable<TriggerPrototypeInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<TriggerPrototypeInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -35,7 +35,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class TriggerPrototypesidsResult : EntityResultBase

--- a/ZabbixApi/Services/TriggerService.cs
+++ b/ZabbixApi/Services/TriggerService.cs
@@ -19,7 +19,7 @@ namespace ZabbixApi.Services
     {
         public TriggerService(IContext context) : base(context, "trigger") { }
 
-        public override IEnumerable<Trigger> Get(object filter = null, IEnumerable<TriggerInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<TriggerInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -39,7 +39,7 @@ namespace ZabbixApi.Services
             
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class TriggersidsResult : EntityResultBase

--- a/ZabbixApi/Services/UserGroupService.cs
+++ b/ZabbixApi/Services/UserGroupService.cs
@@ -18,7 +18,7 @@ namespace ZabbixApi.Services
     {
         public UserGroupService(IContext context) : base(context, "usergroup") { }
 
-        public override IEnumerable<UserGroup> Get(object filter = null, IEnumerable<UserGroupInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<UserGroupInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -29,7 +29,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class UserGroupsidsResult : EntityResultBase

--- a/ZabbixApi/Services/UserlMacroService.cs
+++ b/ZabbixApi/Services/UserlMacroService.cs
@@ -14,11 +14,11 @@ namespace ZabbixApi.Services
         IEnumerable<GlobalMacro> Get(object filter = null, IEnumerable<GlobalMacroInclude> include = null, Dictionary<string, object> @params = null);
     }
 
-    public class GlobalMacroService : ServiceBase<GlobalMacro>, IGlobalMacroService
+    public class GlobalMacroService : ServiceBase<GlobalMacro, GlobalMacroInclude>, IGlobalMacroService
     {
         public GlobalMacroService(IContext context) : base(context, "usermacro") { }
 
-        public IEnumerable<GlobalMacro> Get(object filter = null, IEnumerable<GlobalMacroInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<GlobalMacroInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -29,7 +29,7 @@ namespace ZabbixApi.Services
             
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
     }
 
@@ -48,7 +48,7 @@ namespace ZabbixApi.Services
     {
         public HostMacroService(IContext context) : base(context, "usermacro") { }
 
-        public override IEnumerable<HostMacro> Get(object filter = null, IEnumerable<HostMacroInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<HostMacroInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -61,7 +61,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class HostMacrosidsResult : EntityResultBase

--- a/ZabbixApi/Services/Userservice.cs
+++ b/ZabbixApi/Services/Userservice.cs
@@ -18,7 +18,7 @@ namespace ZabbixApi.Services
     {
         public UserService(IContext context) : base(context, "user") { }
 
-        public override IEnumerable<User> Get(object filter = null, IEnumerable<UserInclude> include = null, Dictionary<string, object> @params = null)
+        protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<UserInclude> include = null, Dictionary<string, object> @params = null)
         {
             var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
             if(@params == null)
@@ -32,7 +32,7 @@ namespace ZabbixApi.Services
 
             @params.AddOrReplace("filter", filter);
             
-            return BaseGet(@params);
+            return @params;
         }
 
         public class UsersidsResult : EntityResultBase

--- a/ZabbixApi/ZabbixApi.csproj
+++ b/ZabbixApi/ZabbixApi.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 


### PR DESCRIPTION
This PR duplicate all sync APIs with an async version along with a few small changes:

* Helpers have been moved to internal (Tell me if it's a problem i'll revert)
* Authentication on Context creation is now optional (There is no way to have an async constructor)
* Async APIs have `IReadOnlyList<T>` in place of `IEnumerable<T>`
* A new reference is added `System.Net.Http`, if my other PR (#37) is merged it'll need to be marked as net45 only too

Fixes #21 