### PR TITLE
Expose service instances directly on the context

### DIFF
--- a/ZabbixApi/IContext.cs
+++ b/ZabbixApi/IContext.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Text;
 using System.IO;
 using System.Configuration;
+using ZabbixApi.Services;
 
 
 namespace ZabbixApi
@@ -51,6 +52,46 @@ namespace ZabbixApi
             Check.IsNotNullOrWhiteSpace(_password, "ZabbixApi.password");
 
             _webClient = new WebClient();
+
+            Actions = new ActionService(this);
+            Alerts = new AlertService(this);
+            ApiInfo = new ApiInfoService(this);
+            Applications = new ApplicationService(this);
+            DiscoveredHosts = new DiscoveredHostService(this);
+            DiscoveredServices = new DiscoveredServiceService(this);
+            DiscoveryChecks = new DiscoveryCheckService(this);
+            DiscoveryRules = new DiscoveryRuleService(this);
+            Events = new EventService(this);
+            GraphItems = new GraphItemService(this);
+            GraphPrototypes = new GraphPrototypeService(this);
+            Graphs = new GraphService(this);
+            History = new HistoryService(this);
+            HostGroups = new HostGroupService(this);
+            HostInterfaces = new HostInterfaceService(this);
+            HostPrototypes = new HostPrototypeService(this);
+            Hosts = new HostService(this);
+            IconMaps = new IconMapService(this);
+            Images = new ImageService(this);
+            ItemPrototypes = new ItemPrototypeService(this);
+            Items = new ItemService(this);
+            LLDRules = new LLDRuleService(this);
+            Maintenance = new MaintenanceService(this);
+            Maps = new MapService(this);
+            Medias = new MediaService(this);
+            MediaTypes = new MediaTypeService(this);
+            Proxies = new ProxyService(this);
+            ScreenItems = new ScreenItemService(this);
+            Screens = new ScreenService(this);
+            Scripts = new ScriptService(this);
+            TemplateScreenItems = new TemplateScreenItemService(this);
+            TemplateScreens = new TemplateScreenService(this);
+            Templates = new TemplateService(this);
+            TriggerPrototypes = new TriggerPrototypeService(this);
+            Triggers = new TriggerService(this);
+            UserGroups = new UserGroupService(this);
+            GlobalMacros = new GlobalMacroService(this);
+            HostMacros = new HostMacroService(this);
+            Users = new UserService(this);
 
             Authenticate();
         }
@@ -106,6 +147,46 @@ namespace ZabbixApi
                 return response.result;
             }
         }
+
+        public ActionService Actions { get; private set; }
+        public AlertService Alerts { get; private set; }
+        public ApiInfoService ApiInfo { get; private set; }
+        public ApplicationService Applications { get; private set; }
+        public DiscoveredHostService DiscoveredHosts { get; private set; }
+        public DiscoveredServiceService DiscoveredServices { get; private set; }
+        public DiscoveryCheckService DiscoveryChecks { get; private set; }
+        public DiscoveryRuleService DiscoveryRules { get; private set; }
+        public EventService Events { get; private set; }
+        public GraphItemService GraphItems { get; private set; }
+        public GraphPrototypeService GraphPrototypes { get; private set; }
+        public GraphService Graphs { get; private set; }
+        public HistoryService History { get; private set; }
+        public HostGroupService HostGroups { get; private set; }
+        public HostInterfaceService HostInterfaces { get; private set; }
+        public HostPrototypeService HostPrototypes { get; private set; }
+        public HostService Hosts { get; private set; }
+        public IconMapService IconMaps { get; private set; }
+        public ImageService Images { get; private set; }
+        public ItemPrototypeService ItemPrototypes { get; private set; }
+        public ItemService Items { get; private set; }
+        public LLDRuleService LLDRules { get; private set; }
+        public MaintenanceService Maintenance { get; private set; }
+        public MapService Maps { get; private set; }
+        public MediaService Medias { get; private set; }
+        public MediaTypeService MediaTypes { get; private set; }
+        public ProxyService Proxies { get; private set; }
+        public ScreenItemService ScreenItems { get; private set; }
+        public ScreenService Screens { get; private set; }
+        public ScriptService Scripts { get; private set; }
+        public TemplateScreenItemService TemplateScreenItems { get; private set; }
+        public TemplateScreenService TemplateScreens { get; private set; }
+        public TemplateService Templates { get; private set; }
+        public TriggerPrototypeService TriggerPrototypes { get; private set; }
+        public TriggerService Triggers { get; private set; }
+        public UserGroupService UserGroups { get; private set; }
+        public GlobalMacroService GlobalMacros { get; private set; }
+        public HostMacroService HostMacros { get; private set; }
+        public UserService Users { get; private set; }
 
         private class Request
         {


### PR DESCRIPTION
Add convenience accessor to allow access to the services like that:

```csharp
using(var zabbix = new Context()) {
    return zabbix.Hosts.Get();
}
```