### PR TITLE
Fixed bug in host.cs

### DIFF
--- a/ZabbixApi/Entities/Host.cs
+++ b/ZabbixApi/Entities/Host.cs
@@ -256,7 +256,7 @@ namespace ZabbixApi.Entities
         /// <summary>
         /// Templates
         /// </summary>
-        public IList<Template> templates { get; set; }
+        public IList<Template> parentTemplates { get; set; }
 
         /// <summary>
         /// Triggers


### PR DESCRIPTION
Zabbix API is returning host's templates as parentTemplates. If field in host.cs is called "templates" json deserialization into Host lose templates.