### PR TITLE
Removed parameter in ApiInfoService request

### DIFF
--- a/ZabbixApi/Services/ApiInfoService.cs
+++ b/ZabbixApi/Services/ApiInfoService.cs
@@ -17,7 +17,7 @@ namespace ZabbixApi.Services
 
         public string GetVersion()
         {
-            var @params = new Dictionary<string, object>() { { "id", 1 } };
+            var @params = new Dictionary<string, object>() { };
             return _context.SendRequest<string>(
                     @params,
                     "apiinfo.version",
@@ -27,7 +27,7 @@ namespace ZabbixApi.Services
 
         public async Task<string> GetVersionAsync()
         {
-            var @params = new Dictionary<string, object>() { { "id", 1 } };
+            var @params = new Dictionary<string, object>() { };
             return await _context.SendRequestAsync<string>(
                 @params,
                 "apiinfo.version",


### PR DESCRIPTION
Parameter "id" is causing Zabbix 4.x API to fail, since "added strict validation of input parameters for version method" (https://www.zabbix.com/documentation/4.0/manual/api/changes_3.4_-_4.0). Removing it solves this problem.